### PR TITLE
Don't always convert from json string to edn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/ring-test-client "0.3.0"
+(defproject clanhr/ring-test-client "0.4.0"
   :description "Utilities for testing controllers on top of ring"
   :url "https://github.com/clanhr/ring-test-client"
   :license {:name "Eclipse Public License"

--- a/src/clanhr/ring_test_client/core.clj
+++ b/src/clanhr/ring_test_client/core.clj
@@ -5,6 +5,12 @@
   (:use clojure.test
         ring.mock.request))
 
+(defn ->edn [raw]
+  (cond
+    (coll? raw) raw
+    (string? raw) (json/build raw)
+    :else (json/build (slurp raw))))
+
 (defn http-plain-get
   "Creates a GET request. Translates edn -> json -> edn"
   ([app path]
@@ -17,11 +23,11 @@
   "Creates a GET request. Translates edn -> json -> edn"
   ([app path]
    (let [response (app (request :get path))]
-     (assoc response :body (json/build (:body response)))))
+     (assoc response :body (->edn (:body response)))))
   ([app path data hh]
    (let [response (app (-> (request :get path)
                            (header (first hh) (second hh))))]
-     (assoc response :body (json/build (:body response))))))
+     (assoc response :body (->edn (:body response))))))
 
 (defn post
   "Creates a POST request. Translates edn -> json -> edn"
@@ -29,7 +35,7 @@
    (post app path {}))
   ([app path data]
     (let [response (app (request :post path (json/dump data)))]
-      (assoc response :body (json/build (:body response))))))
+      (assoc response :body (->edn (:body response))))))
 
 (defn put
   "Creates a PUT request. Translates edn -> json -> edn"
@@ -37,8 +43,7 @@
    (put app path {}))
   ([app path data]
     (let [response (app (request :put path (json/dump data)))]
-      (println response)
-      (assoc response :body (json/build (:body response))))))
+      (assoc response :body (->edn (:body response))))))
 
 (defn auth-put
   "Creates a PUT request authed for the given user. Translates edn -> json -> edn"
@@ -48,7 +53,7 @@
    (let [request (-> (request :put path (json/dump data))
                      (assoc-in [:headers "x-clanhr-auth-token"] (:token user)))
          response (app request)]
-     (assoc response :body (json/build (:body response))))))
+     (assoc response :body (->edn (:body response))))))
 
 (defn auth-post
   "Creates a POST request authed for the given user. Translates edn -> json -> edn"
@@ -58,7 +63,7 @@
    (let [request (-> (request :post path (json/dump data))
                      (assoc-in [:headers "x-clanhr-auth-token"] (:token user)))
          response (app request)]
-     (assoc response :body (json/build (:body response))))))
+     (assoc response :body (->edn (:body response))))))
 
 (defn auth-get
   "Creates a GET request authed for the given user. Translates edn -> json -> edn"
@@ -66,7 +71,7 @@
   (let [request (-> (request :get path)
                     (assoc-in [:headers "x-clanhr-auth-token"] (:token user)))
         response (app request)]
-    (assoc response :body (json/build (:body response)))))
+    (assoc response :body (->edn (:body response)))))
 
 (defn auth-plain-get
   "Creates a GET request authed for the given user."


### PR DESCRIPTION
Motivation:

With the swagger lib, the reply now does not return a json string, but
actual edn.

Modifications:

Create a fn that is smart enough on how to convert to edn. If the param
is already a clojure object return it. If it's a string, build as json.
Else, it may be a stream that will handle a string, so slurp it and
build as json.
